### PR TITLE
Update es.json to get the auth alerts to show up in the interface

### DIFF
--- a/auth/es.json
+++ b/auth/es.json
@@ -171,7 +171,8 @@
           "type": "text"
         },
         "source:type": {
-          "type": "text"
+          "index": true,
+          "type": "keyword"
         },
         "source_file": {
           "index": true,


### PR DESCRIPTION
required change for the alerts UI to work, REST service will otherwise complain with this error:

Fielddata is disabled on text fields by default. Set fielddata=true on [source:type] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.