### PR TITLE
Update bootstrap.sh to include zookeeper option in all instances when using zk_load_configs.sh

### DIFF
--- a/auth/remote/bootstrap.sh
+++ b/auth/remote/bootstrap.sh
@@ -2,7 +2,7 @@
 set -a 
 source /etc/default/metron
 
-sudo $METRON_HOME/bin/zk_load_configs.sh -m PULL -o ${METRON_HOME}/config/zookeeper/ -f 
+sudo $METRON_HOME/bin/zk_load_configs.sh -z $ZOOKEEPER -m PULL -o ${METRON_HOME}/config/zookeeper/ -f 
 
 if [ ! -f ${METRON_HOME}/config/zookeeper/profiler.json ] 
 then 


### PR DESCRIPTION
zk_load_configs.sh requires the zookeeper option to be present